### PR TITLE
Add OS X and Strawberry support.

### DIFF
--- a/alienfile
+++ b/alienfile
@@ -3,6 +3,9 @@ use alienfile;
 plugin 'PkgConfig' => 'libuv';
 
 share {
+  # note on apple weirdisms: https://github.com/joyent/libuv/issues/1200
+  meta->prop->{env}->{LIBTOOLIZE} = 'libtoolize' if $^O eq 'darwin';
+
   requires 'Alien::autoconf';
   requires 'Alien::automake';
   requires 'Alien::libtool';

--- a/alienfile
+++ b/alienfile
@@ -3,6 +3,10 @@ use alienfile;
 plugin 'PkgConfig' => 'libuv';
 
 share {
+  requires 'Alien::autoconf';
+  requires 'Alien::automake';
+  requires 'Alien::libtool';
+
   plugin Download => (
     url     => 'http://dist.libuv.org/dist/v1.12.0',
     version => qr/^libuv-v([0-9\.]+)\.tar\.gz$/,

--- a/t/ffi.t
+++ b/t/ffi.t
@@ -1,0 +1,13 @@
+use Test2::V0;
+use Test::Alien;
+use Alien::libuv;
+
+alien_ok 'Alien::libuv';
+ffi_ok { symbols => ['uv_version_string'] }, with_subtest {
+  my($ffi) = @_;
+  my $version = $ffi->function(uv_version_string => [] => 'string')->call;
+  ok $version, 'version returns okay';
+  note "version=$version";  
+};
+
+done_testing;

--- a/t/xs.t
+++ b/t/xs.t
@@ -1,0 +1,26 @@
+use Test2::V0;
+use Test::Alien;
+use Alien::libuv;
+
+alien_ok 'Alien::libuv';
+xs_ok do { local $/; <DATA> }, with_subtest {
+  my $version = UVTest::uv_version_string();
+  ok $version, 'version returns okay';
+  note "version=$version";
+};
+
+done_testing;
+
+__END__
+
+#include "EXTERN.h"
+#include "perl.h"
+#include "XSUB.h"
+#include <uv.h>
+
+MODULE = UVTest PACKAGE = UVTest
+
+const char *
+uv_version_string()
+
+


### PR DESCRIPTION
The main goal of this work was to get stuff working on Strawberry Perl.  To that end I created aliens for autoconf, automake and libtool.  In my testing on OS X I found that libuv tries to use glibtoolize because the libtool that comes with OS X is borked.  Since we are using Alien::libtool that isn't a problem, and (on my system at least) there is no glibtoolize.  I've also added a couple of tests using Test::Alien.  I have found that it helps keep a bad alien from installing before handing it off to the XS that uses it.