### PR TITLE
Windows Libraries and Flags

### DIFF
--- a/Changes
+++ b/Changes
@@ -2,6 +2,9 @@ Revision history for {{$dist->name}}
 
 {{$NEXT}}
   - Update to the libuv v1.20.0 release
+  - Bump to major version 1 to reflect same major version as libuv.
+  - Update the alienfile to add the various libs needed on Win32
+  - Update the alienfile to add the various cflags needed on Win32
 
 0.017     2018-03-29
   - Update to the libuv v1.19.2 release

--- a/META.json
+++ b/META.json
@@ -88,7 +88,7 @@
    "provides" : {
       "Alien::libuv" : {
          "file" : "lib/Alien/libuv.pm",
-         "version" : "0.018"
+         "version" : "1.000"
       }
    },
    "release_status" : "stable",
@@ -103,7 +103,7 @@
          "web" : "https://github.com/genio/Alien-libuv"
       }
    },
-   "version" : "0.018",
+   "version" : "1.000",
    "x_Dist_Zilla" : {
       "perl" : {
          "version" : "5.026001"
@@ -420,7 +420,7 @@
                   "branch" : null,
                   "changelog" : "Changes",
                   "signed" : 0,
-                  "tag" : "v0.018",
+                  "tag" : "v1.000",
                   "tag_format" : "v%v",
                   "tag_message" : "v%v"
                },

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -43,7 +43,7 @@ my %WriteMakefileArgs = (
     "Test::Alien" => 0,
     "Test::More" => "0.88"
   },
-  "VERSION" => "0.018",
+  "VERSION" => "1.000",
   "test" => {
     "TESTS" => "t/*.t"
   }

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ In your `Makefile.PL`:
     WriteMakefile(
       ...
       CONFIGURE_REQUIRES => {
-        'Alien::libuv' => '0',
+        'Alien::libuv' => '1.000',
       },
       CCFLAGS => Alien::libuv->cflags . " $Config{ccflags}",
       LIBS    => [ Alien::libuv->libs ],

--- a/alienfile
+++ b/alienfile
@@ -1,4 +1,36 @@
 use alienfile;
+use Config;
+
+sub WINVER() {
+    return undef unless $^O eq 'MSWin32';
+    my $ver;
+    my $err = do {
+        local $@;
+        eval { require Win32; $ver = Win32::GetOSName(); 1; };
+        $@;
+    };
+    $ver = 'Win10' unless $ver; # just pick one if we couldn't find it
+    if ($err) {
+        warn "We had an error grabbing the Win32 OS Name: $err";
+    }
+
+    if ($ver =~ /^Win(?:Win32s|95|98|Me|NT4|NT3\.51|HomeSvr)/) {
+        warn "This version of Windows is really old and we can't install here";
+        exit(1);
+    }
+    return '0x0500' if $ver =~ /^Win2000/;
+    return '0x0501' if $ver =~ /^WinXP\/\.Net/;
+    return '0x0502' if $ver =~ /^Win2003/;
+    return '0x0600' if $ver =~ /^Win(?:Vista|2008)/;
+    return '0x0601' if $ver =~ /^Win7/;
+    return '0x0603' if $ver =~ /^Win8\.1/;
+    return '0x0602' if $ver =~ /^Win8/;
+    return '0x0A00' if $ver =~ /^Win10/;
+    return '0x0A00' if $ver =~ /^Win(?:2012|2014|2016)/; # not sure here
+
+    warn "We couldn't determine the version of Windows you're on.";
+    return undef;
+}
 
 configure { requires 'Alien::Build::Plugin::Build::Make' => '0.01' };
 
@@ -20,6 +52,7 @@ share {
 
   if($^O eq 'MSWin32')
   {
+    my $bits = $Config{archname} =~ /^MSWin32-x64/ ? 64 : 32;
     requires 'Path::Tiny';
     plugin 'Build::Make' => 'gmake';
 
@@ -31,6 +64,17 @@ share {
         meta->interpolator->add_helper(prefix_win => sub { $prefix });
       }
     );
+
+    meta->after_hook(gather_share => sub {
+        my $build= shift;
+        my $flags = '-DWin32';
+        $flags .= ' -DWin64' if $bits == 64;
+        if (my $ver = WINVER()) {
+            $flags .= " -D_WINVER=$ver -D_WIN32_WINNT=$ver"
+        }
+        $build->runtime_prop->{$_} .= " $flags" for qw( cflags cflags_static );
+        $build->runtime_prop->{$_} .= ' -lpsapi -luserenv -lIphlpapi' for qw( libs libs_static );
+    });
 
     build [
       '%{make} -f Makefile.mingw CC=%{perl.config.cc}',

--- a/dist.ini
+++ b/dist.ini
@@ -3,7 +3,7 @@ author           = Chase Whitener <capoeirab@cpan.org>
 license          = Perl_5
 copyright_holder = Chase Whitener
 copyright_year   = 2017
-version          = 0.018
+version          = 1.000
 
 [Git::GatherDir]
 exclude_filename = Makefile.PL

--- a/lib/Alien/libuv.pm
+++ b/lib/Alien/libuv.pm
@@ -29,7 +29,7 @@ In your C<Makefile.PL>:
     WriteMakefile(
       ...
       CONFIGURE_REQUIRES => {
-        'Alien::libuv' => '0',
+        'Alien::libuv' => '1.000',
       },
       CCFLAGS => Alien::libuv->cflags . " $Config{ccflags}",
       LIBS    => [ Alien::libuv->libs ],

--- a/lib/Alien/libuv.pm
+++ b/lib/Alien/libuv.pm
@@ -4,7 +4,7 @@ use strict;
 use warnings;
 use base qw( Alien::Base );
 
-our $VERSION = '0.018';
+our $VERSION = '1.000';
 $VERSION = eval $VERSION;
 
 1;


### PR DESCRIPTION
On Windows, go ahead and add the flags and libraries we'll need to build anything against libuv v1.x.

Bump the version number to 1.x to stay on the same major version as libuv.

Update the documentation to reflect the version number change.