### PR TITLE
Cmake

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -8,6 +8,8 @@ environment:
   matrix:
     - perl_type: cygwin
     - perl_type: strawberry
+      perl_version: 5.28.0.1
+    - perl_type: strawberry
       perl_version: 5.26.1.1
     - perl_type: strawberry
       perl_version: 5.24.3.1

--- a/META.json
+++ b/META.json
@@ -26,11 +26,8 @@
    "prereqs" : {
       "build" : {
          "requires" : {
-            "Alien::Base" : "0",
-            "Alien::Build" : "0.32",
+            "Alien::Build" : "1.00",
             "Alien::Build::MM" : "0.32",
-            "Alien::Build::Plugin::Build::Autoconf" : "0",
-            "Alien::Build::Plugin::Gather::IsolateDynamic" : "0",
             "Config" : "0",
             "ExtUtils::MakeMaker" : "6.52",
             "IPC::Cmd" : "0"
@@ -46,6 +43,7 @@
       },
       "develop" : {
          "requires" : {
+            "Dist::Zilla" : "0",
             "File::Spec" : "0",
             "IO::Handle" : "0",
             "IPC::Open3" : "0",
@@ -63,7 +61,7 @@
       },
       "runtime" : {
          "requires" : {
-            "Alien::Base" : "0",
+            "Alien::Base" : "1.00",
             "base" : "0",
             "perl" : "5.008001",
             "strict" : "0",
@@ -313,6 +311,26 @@
             "class" : "Dist::Zilla::Plugin::Prereqs::FromCPANfile",
             "name" : "Prereqs::FromCPANfile",
             "version" : "0.08"
+         },
+         {
+            "class" : "Dist::Zilla::Plugin::OSPrereqs",
+            "config" : {
+               "Dist::Zilla::Plugin::OSPrereqs" : {
+                  "os" : "!~win"
+               }
+            },
+            "name" : "!~win",
+            "version" : "0.011"
+         },
+         {
+            "class" : "Dist::Zilla::Plugin::OSPrereqs",
+            "config" : {
+               "Dist::Zilla::Plugin::OSPrereqs" : {
+                  "os" : "MSWin32"
+               }
+            },
+            "name" : "MSWin32",
+            "version" : "0.011"
          },
          {
             "class" : "Dist::Zilla::Plugin::MetaProvides::Package",
@@ -609,6 +627,6 @@
       "Graham Ollis <plicease@cpan.org>"
    ],
    "x_generated_by_perl" : "v5.26.1",
-   "x_serialization_backend" : "Cpanel::JSON::XS version 4.02"
+   "x_serialization_backend" : "Cpanel::JSON::XS version 4.04"
 }
 

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -10,11 +10,8 @@ my %WriteMakefileArgs = (
   "ABSTRACT" => "Interface to the libuv library L<http://libuv.org>",
   "AUTHOR" => "Chase Whitener <capoeirab\@cpan.org>",
   "BUILD_REQUIRES" => {
-    "Alien::Base" => 0,
-    "Alien::Build" => "0.32",
+    "Alien::Build" => "1.00",
     "Alien::Build::MM" => "0.32",
-    "Alien::Build::Plugin::Build::Autoconf" => 0,
-    "Alien::Build::Plugin::Gather::IsolateDynamic" => 0,
     "Config" => 0,
     "ExtUtils::MakeMaker" => "6.52",
     "IPC::Cmd" => 0
@@ -30,7 +27,7 @@ my %WriteMakefileArgs = (
   "MIN_PERL_VERSION" => "5.008001",
   "NAME" => "Alien::libuv",
   "PREREQ_PM" => {
-    "Alien::Base" => 0,
+    "Alien::Base" => "1.00",
     "base" => 0,
     "strict" => 0,
     "warnings" => 0
@@ -51,11 +48,9 @@ my %WriteMakefileArgs = (
 
 
 my %FallbackPrereqs = (
-  "Alien::Base" => 0,
-  "Alien::Build" => "0.32",
+  "Alien::Base" => "1.00",
+  "Alien::Build" => "1.00",
   "Alien::Build::MM" => "0.32",
-  "Alien::Build::Plugin::Build::Autoconf" => 0,
-  "Alien::Build::Plugin::Gather::IsolateDynamic" => 0,
   "Config" => 0,
   "ExtUtils::MakeMaker" => "6.52",
   "File::Spec" => 0,
@@ -85,6 +80,16 @@ unless ( eval { ExtUtils::MakeMaker->VERSION(6.63_03) } ) {
 
 delete $WriteMakefileArgs{CONFIGURE_REQUIRES}
   unless eval { ExtUtils::MakeMaker->VERSION(6.52) };
+
+if ( $^O !~ /win/i ) {
+	$WriteMakefileArgs{PREREQ_PM}{'Alien::Autotools'} = $FallbackPrereqs{'Alien::Autotools'} = '1.00';
+	$WriteMakefileArgs{PREREQ_PM}{'Alien::Build::Plugin::Build::Autoconf'} = $FallbackPrereqs{'Alien::Build::Plugin::Build::Autoconf'} = '0.04';
+}
+
+if ( $^O eq 'MSWin32' ) {
+	$WriteMakefileArgs{PREREQ_PM}{'Alien::Build::Plugin::Build::CMake'} = $FallbackPrereqs{'Alien::Build::Plugin::Build::CMake'} = '0';
+	$WriteMakefileArgs{PREREQ_PM}{'Alien::cmake3'} = $FallbackPrereqs{'Alien::cmake3'} = '0.04';
+}
 
 WriteMakefile(%WriteMakefileArgs);
 

--- a/alienfile
+++ b/alienfile
@@ -46,90 +46,100 @@ plugin 'PkgConfig' => (
 );
 
 share {
-  # note on apple weirdisms: https://github.com/joyent/libuv/issues/1200
-  meta->prop->{env}->{LIBTOOLIZE} = 'libtoolize' if $^O eq 'darwin';
+    # note on apple weirdisms: https://github.com/joyent/libuv/issues/1200
+    meta->prop->{env}->{LIBTOOLIZE} = 'libtoolize' if $^O eq 'darwin';
 
-  plugin Download => (
-    url     => 'https://dist.libuv.org/dist/v1.21.0',
-    version => qr/^libuv-v([0-9\.]+)\.tar\.gz$/,
-  );
-
-  plugin Extract => 'tar.gz';
-
-  if($^O eq 'MSWin32')
-  {
-    my $bits = $Config{archname} =~ /^MSWin32-x64/ ? 64 : 32;
-    requires 'Path::Tiny';
-    plugin 'Build::Make' => 'gmake';
-
-    meta->before_hook(
-      build => sub {
-        my($build) = @_;
-        my $prefix = $build->install_prop->{prefix};
-        $prefix =~ s{/}{\\}g;
-        meta->interpolator->add_helper(prefix_win => sub { $prefix });
-      }
+    plugin Download => (
+        url     => 'https://dist.libuv.org/dist/v1.22.0',
+        version => qr/^libuv-v([0-9\.]+)\.tar\.gz$/,
     );
 
-    meta->after_hook(gather_share => sub {
-        my $build= shift;
-        my $flags = '-DWIN32 -D_WIN32';
-        $flags .= ' -DWIN64 -D_WIN64' if $bits == 64;
-        if (my $ver = WINVER()) {
-            $flags .= " -D_WINVER=$ver -D_WIN32_WINNT=$ver"
-        }
-        $build->runtime_prop->{$_} .= " $flags" for qw( cflags cflags_static );
-        # on windows, we need the following libraries to be included. MinGW can't pull these
-        # from source on windows, so we add the equivalent to these pragma comments
-        # to our libs/libs_static area:
-        #pragma comment(lib, "Advapi32.lib")
-        #pragma comment(lib, "IPHLPAPI.lib")
-        #pragma comment(lib, "kernel32.lib")
-        #pragma comment(lib, "Psapi.lib")
-        #pragma comment(lib, "User32.lib")
-        #pragma comment(lib, "Userenv.lib")
-        #pragma comment(lib, "Ws2_32.lib")
-        $build->runtime_prop->{$_} .= ' -ladvapi32 -lIphlpapi -lkernel32 -lpsapi -luser32 -luserenv -lws2_32' for qw( libs libs_static );
-    });
+    plugin Extract => 'tar.gz';
 
-    build [
-      '%{make} -f Makefile.mingw CC=%{perl.config.cc}',
-      'mkdir %{prefix_win}\\lib',
-      'mkdir %{prefix_win}\\lib\\pkgconfig',
-      'copy libuv.a %{prefix_win}\\lib',
-      'mkdir %{prefix_win}\\include',
-      'copy include\\*.h %{prefix_win}\\include',
-      sub {
-        my($build) = @_;
-        my($pc) = Path::Tiny->new('libuv.pc.in')->slurp;
+    if($^O eq 'MSWin32') {
+        my $bits = $Config{archname} =~ /^MSWin32-x64/ ? 64 : 32;
+        requires 'Path::Tiny';
+        plugin 'Build::Make' => 'gmake';
+        plugin 'Build::CMake';
 
-        my $prefix = $build->runtime_prop->{prefix};
-        my $version = $build->runtime_prop->{version};
+        my @args = (
+            -G => '%{cmake_generator}',
+            '-DCMAKE_POSITION_INDEPENDENT_CODE:BOOL=true',
+            '-DCMAKE_INSTALL_PREFIX:PATH=%{.install.prefix}',
+            '-DCMAKE_MAKE_PROGRAM:PATH=%{make}',
+        );
 
-        $pc =~ s{\@prefix\@}{$prefix}g;
-        $pc =~ s{\@libdir\@}{$prefix/lib}g;
-        $pc =~ s{\@includedir\@}{$prefix/include}g;
-        $pc =~ s{\@PACKAGE_NAME\@}{libuv}g;
-        $pc =~ s{\@PACKAGE_VERSION\@}{$version}g;
-        $pc =~ s{\@LIBS\@}{}g;
+        meta->before_hook(build => sub {
+            my($build) = @_;
+            my $prefix = $build->install_prop->{prefix};
+            $prefix =~ s{/}{\\}g;
+            meta->interpolator->add_helper(prefix_win => sub { $prefix });
+        });
 
-        Path::Tiny->new($build->install_prop->{prefix})->child('lib/pkgconfig/libuv.pc')->spew($pc);
-      },
-    ];
-  }
-  else
-  {
-    requires 'Alien::Autotools';
-    plugin 'Build::Autoconf' => ();
+        meta->after_hook(gather_share => sub {
+            my $build= shift;
+            my $flags = '-DWIN32 -D_WIN32';
+            $flags .= ' -DWIN64 -D_WIN64' if $bits == 64;
+            if (my $ver = WINVER()) {
+                $flags .= " -D_WINVER=$ver -D_WIN32_WINNT=$ver"
+            }
+            $build->runtime_prop->{$_} .= " $flags" for qw( cflags cflags_static );
+            # on windows, we need the following libraries to be included. MinGW can't pull these
+            # from source on windows, so we add the equivalent to these pragma comments
+            # to our libs/libs_static area:
+            #pragma comment(lib, "Advapi32.lib")
+            #pragma comment(lib, "IPHLPAPI.lib")
+            #pragma comment(lib, "kernel32.lib")
+            #pragma comment(lib, "Psapi.lib")
+            #pragma comment(lib, "Shell32.lib")
+            #pragma comment(lib, "User32.lib")
+            #pragma comment(lib, "Userenv.lib")
+            #pragma comment(lib, "Ws2_32.lib")
+            $build->runtime_prop->{$_} .= ' -ladvapi32 -lIphlpapi -lkernel32 -lpsapi -lshell32 -luser32 -luserenv -lws2_32' for qw( libs libs_static );
+        });
 
-    build [
-      'sh autogen.sh',
-      '%{configure}',
-      '%{make}',
-      '%{make} test',
-      '%{make} install',
-    ];
-  }
+        build [
+            ['%{cmake}', @args, '%{.install.extract}' ],
+            ['%{make}' ],
+            'mkdir %{prefix_win}\\lib',
+            'mkdir %{prefix_win}\\lib\\pkgconfig',
+            'copy libuv_a.a %{prefix_win}\\lib\\libuv.a',
+            'copy libuv.dll %{prefix_win}\\lib',
+            'copy libuv.dll.a %{prefix_win}\\lib',
+            'mkdir %{prefix_win}\\include',
+            'mkdir %{prefix_win}\\include\\uv',
+            'copy include\\*.h %{prefix_win}\\include',
+            'copy include\\uv\\*.h %{prefix_win}\\include\\uv',
+            sub {
+                my($build) = @_;
+                my($pc) = Path::Tiny->new('libuv.pc.in')->slurp;
 
-  plugin 'Gather::IsolateDynamic' => ();
+                my $prefix = $build->runtime_prop->{prefix};
+                my $version = $build->runtime_prop->{version};
+
+                $pc =~ s{\@prefix\@}{$prefix}g;
+                $pc =~ s{\@libdir\@}{$prefix/lib}g;
+                $pc =~ s{\@includedir\@}{$prefix/include}g;
+                $pc =~ s{\@PACKAGE_NAME\@}{libuv}g;
+                $pc =~ s{\@PACKAGE_VERSION\@}{$version}g;
+                $pc =~ s{\@LIBS\@}{}g;
+
+                Path::Tiny->new($build->install_prop->{prefix})->child('lib/pkgconfig/libuv.pc')->spew($pc);
+            },
+        ];
+    }
+    else {
+        requires 'Alien::Autotools';
+        plugin 'Build::Autoconf' => ();
+
+        build [
+            'sh autogen.sh',
+            '%{configure}',
+            '%{make}',
+            '%{make} test',
+            '%{make} install',
+        ];
+    }
+
+    plugin 'Gather::IsolateDynamic' => ();
 };

--- a/cpanfile
+++ b/cpanfile
@@ -3,15 +3,11 @@ on 'runtime' => sub {
     requires 'strict';
     requires 'warnings';
     requires 'base';
-    requires 'Alien::Base';
+    requires 'Alien::Base' => '1.00';
 };
 
 on 'build' => sub {
-    requires 'Alien::Base';
-    requires 'Alien::Build';
-    requires 'Alien::Build::MM';
-    requires 'Alien::Build::Plugin::Build::Autoconf';
-    requires 'Alien::Build::Plugin::Gather::IsolateDynamic';
+    requires 'Alien::Build' => '1.00';
     requires 'Config';
     requires 'ExtUtils::MakeMaker';
     requires 'IPC::Cmd';
@@ -27,6 +23,7 @@ on 'test' => sub {
 };
 
 on 'develop' => sub {
+    requires 'Dist::Zilla';
     requires 'Test::CheckManifest' => '1.29';
     requires 'Test::CPAN::Changes' => '0.4';
     requires 'Test::Kwalitee'      => '1.22';

--- a/dist.ini
+++ b/dist.ini
@@ -27,6 +27,19 @@ filename = README.md
 location = root
 
 [Prereqs::FromCPANfile]
+
+; These next prereqs are _NOT_ listed in the cpanfile:
+
+; require on non-Win32 systems
+[OSPrereqs / !~win]
+Alien::Autotools = 1.00
+Alien::Build::Plugin::Build::Autoconf = 0.04
+
+; require on Win32 systems
+[OSPrereqs / MSWin32]
+Alien::Build::Plugin::Build::CMake = 0
+Alien::cmake3 = 0.04
+
 [MetaProvides::Package]
 
 [NextRelease]


### PR DESCRIPTION
With the latest releases of libuv, the addition of CMake has made building for windows a bit better and is actually maintained.

We'll leave the non-MSWin32 builds using the auto tools as most other systems already have this (```sudo apt install build-essential```, etc.).

Also, rather than trying to keep OS-specific prereqs in the cpanfile, remove those and use the `OSPrereqs` dzil plugin and leave those as dynamic prereqs.