### PR TITLE
Revert removal of _WIN32_WINNT and WINVER flags 

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,6 +1,8 @@
 Revision history for {{$dist->name}}
 
 {{$NEXT}}
+  - Update to the libuv v1.25.0 release
+  - Re-add the previously removed build flags for Windows
 
 1.007     2019-01-13
   - Update to the libuv v1.24.1 release

--- a/alienfile
+++ b/alienfile
@@ -13,7 +13,7 @@ share {
     meta->prop->{env}->{LIBTOOLIZE} = 'libtoolize' if $^O eq 'darwin';
 
     plugin Download => (
-        url     => 'https://dist.libuv.org/dist/v1.24.1',
+        url     => 'https://dist.libuv.org/dist/v1.25.0',
         version => qr/^libuv-v([0-9\.]+)\.tar\.gz$/,
     );
 
@@ -41,9 +41,10 @@ share {
 
         meta->after_hook(gather_share => sub {
             my $build= shift;
+            my $ver = '0x0601'; # win7+ compat
             my $flags = '-DWIN32 -D_WIN32';
             $flags .= ' -DWIN64 -D_WIN64' if $bits == 64;
-
+            $flags .= " -D_WIN32_WINNT=$ver -DWINVER=$ver";
             $build->runtime_prop->{$_} .= " $flags" for qw( cflags cflags_static );
             # on windows, we need the following libraries to be included. MinGW can't pull these
             # from source on windows, so we add the equivalent to these pragma comments


### PR DESCRIPTION
as they are necessary on Windows due to MinGW not including them on the version released with older Strawberry Perls.
Bump the version of libuv to v1.25.0