### PR TITLE
add support for Visual C++ + vcpkg

### DIFF
--- a/Changes
+++ b/Changes
@@ -6,6 +6,7 @@ Revision history for {{$dist->name}}
     prior to this update
   - Bump prereq to Alien::Build v2.11 to get Probe::Vcpkg
   - Move testing phase to the correct place for the library on non-Windows
+  - Update to the libuv v1.35.0 release
 
 1.012     2019-08-31
   - Update to the libuv v1.31.0 release

--- a/Changes
+++ b/Changes
@@ -4,7 +4,7 @@ Revision history for {{$dist->name}}
   - Update documentation and build to use Alien::Base::Wrapper
     This handles edge cases of prereqs that we didn't get manually
     prior to this update
-  - Bump prereq to Alien::Build v2.11 to get Probe::Vcpkg
+  - Bump prereq to Alien::Build v2.15 to get Probe::Vcpkg
   - Move testing phase to the correct place for the library on non-Windows
   - Update to the libuv v1.35.0 release
 

--- a/Changes
+++ b/Changes
@@ -6,7 +6,7 @@ Revision history for {{$dist->name}}
     prior to this update
   - Bump prereq to Alien::Build v2.15 to get Probe::Vcpkg
   - Move testing phase to the correct place for the library on non-Windows
-  - Update to the libuv v1.35.0 release
+  - Update to the libuv v1.34.2 release
 
 1.012     2019-08-31
   - Update to the libuv v1.31.0 release

--- a/Changes
+++ b/Changes
@@ -1,6 +1,11 @@
 Revision history for {{$dist->name}}
 
 {{$NEXT}}
+  - Update documentation and build to use Alien::Base::Wrapper
+    This handles edge cases of prereqs that we didn't get manually
+    prior to this update
+  - Bump prereq to Alien::Build v2.11 to get Probe::Vcpkg
+  - Move testing phase to the correct place for the library on non-Windows
 
 1.012     2019-08-31
   - Update to the libuv v1.31.0 release

--- a/META.json
+++ b/META.json
@@ -26,9 +26,10 @@
    "prereqs" : {
       "build" : {
          "requires" : {
-            "Alien::Build" : "1.00",
+            "Alien::Build" : "2.11",
             "Alien::Build::MM" : "0.32",
             "Alien::Build::Plugin::Build::Make" : "0",
+            "Alien::Build::Plugin::Probe::Vcpkg" : "2.11",
             "Config" : "0",
             "ExtUtils::MakeMaker" : "6.52",
             "IPC::Cmd" : "0"
@@ -36,9 +37,10 @@
       },
       "configure" : {
          "requires" : {
-            "Alien::Build" : "0.32",
+            "Alien::Build" : "1.14",
             "Alien::Build::MM" : "0.32",
             "Alien::Build::Plugin::Build::Make" : "0.01",
+            "Alien::Build::Plugin::Probe::Vcpkg" : "2.14",
             "ExtUtils::MakeMaker" : "6.52"
          }
       },
@@ -62,7 +64,7 @@
       },
       "runtime" : {
          "requires" : {
-            "Alien::Base" : "1.00",
+            "Alien::Base" : "2.11",
             "base" : "0",
             "perl" : "5.008001",
             "strict" : "0",
@@ -87,7 +89,7 @@
    "provides" : {
       "Alien::libuv" : {
          "file" : "lib/Alien/libuv.pm",
-         "version" : "1.012"
+         "version" : "1.013"
       }
    },
    "release_status" : "stable",
@@ -102,7 +104,7 @@
          "web" : "https://github.com/genio/Alien-libuv"
       }
    },
-   "version" : "1.012",
+   "version" : "1.013",
    "x_Dist_Zilla" : {
       "perl" : {
          "version" : "5.026001"
@@ -367,7 +369,7 @@
                   "branch" : null,
                   "changelog" : "Changes",
                   "signed" : 0,
-                  "tag" : "1.012",
+                  "tag" : "1.013",
                   "tag_format" : "%v",
                   "tag_message" : "%v"
                },
@@ -690,10 +692,11 @@
             "Alien::Build::Plugin::Gather::IsolateDynamic" : "0.48",
             "Archive::Tar" : "0",
             "Config" : "0",
-            "HTML::LinkExtor" : "0",
             "HTTP::Tiny" : "0.044",
             "IO::Socket::SSL" : "1.56",
             "IO::Zlib" : "0",
+            "Mojo::DOM" : "0",
+            "Mojolicious" : "7.00",
             "Net::SSLeay" : "1.49",
             "Sort::Versions" : "0",
             "URI" : "0",

--- a/META.json
+++ b/META.json
@@ -37,7 +37,7 @@
       },
       "configure" : {
          "requires" : {
-            "Alien::Build" : "1.14",
+            "Alien::Build" : "2.11",
             "Alien::Build::MM" : "0.32",
             "Alien::Build::Plugin::Build::Make" : "0.01",
             "Alien::Build::Plugin::Probe::Vcpkg" : "2.14",

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -31,24 +31,26 @@ my %WriteMakefileArgs = (
   "ABSTRACT" => "Interface to the libuv library L<http://libuv.org>",
   "AUTHOR" => "Chase Whitener <capoeirab\@cpan.org>",
   "BUILD_REQUIRES" => {
-    "Alien::Build" => "1.00",
+    "Alien::Build" => "2.11",
     "Alien::Build::MM" => "0.32",
     "Alien::Build::Plugin::Build::Make" => 0,
+    "Alien::Build::Plugin::Probe::Vcpkg" => "2.11",
     "Config" => 0,
     "ExtUtils::MakeMaker" => "6.52",
     "IPC::Cmd" => 0
   },
   "CONFIGURE_REQUIRES" => {
-    "Alien::Build" => "0.32",
+    "Alien::Build" => "1.14",
     "Alien::Build::MM" => "0.32",
     "Alien::Build::Plugin::Build::Make" => "0.01",
+    "Alien::Build::Plugin::Probe::Vcpkg" => "2.14",
     "ExtUtils::MakeMaker" => "6.52"
   },
   "DISTNAME" => "Alien-libuv",
   "LICENSE" => "perl",
   "NAME" => "Alien::libuv",
   "PREREQ_PM" => {
-    "Alien::Base" => "1.00",
+    "Alien::Base" => "2.11",
     "base" => 0,
     "strict" => 0,
     "warnings" => 0
@@ -68,10 +70,11 @@ my %WriteMakefileArgs = (
 );
 
 my %FallbackPrereqs = (
-  "Alien::Base" => "1.00",
-  "Alien::Build" => "1.00",
+  "Alien::Base" => "2.11",
+  "Alien::Build" => "2.11",
   "Alien::Build::MM" => "0.32",
   "Alien::Build::Plugin::Build::Make" => 0,
+  "Alien::Build::Plugin::Probe::Vcpkg" => "2.11",
   "Config" => 0,
   "ExtUtils::MakeMaker" => "6.52",
   "File::Spec" => 0,

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -40,7 +40,7 @@ my %WriteMakefileArgs = (
     "IPC::Cmd" => 0
   },
   "CONFIGURE_REQUIRES" => {
-    "Alien::Build" => "1.14",
+    "Alien::Build" => "2.11",
     "Alien::Build::MM" => "0.32",
     "Alien::Build::Plugin::Build::Make" => "0.01",
     "Alien::Build::Plugin::Probe::Vcpkg" => "2.14",

--- a/README.md
+++ b/README.md
@@ -15,16 +15,16 @@ use warnings;
 
 use ExtUtils::MakeMaker;
 use Config;
-use Alien::libuv;
+use Alien::Base::Wrapper ();
 
 WriteMakefile(
-  ...
-  CONFIGURE_REQUIRES => {
-    'Alien::libuv' => '1.000',
-  },
-  CCFLAGS => Alien::libuv->cflags . " $Config{ccflags}",
-  LIBS    => [ Alien::libuv->libs ],
-  ...
+  Alien::Base::Wrapper->new('Alien::libuv')->mm_args2(
+    ...
+    CONFIGURE_REQUIRES => {
+      'Alien::libuv' => '1.000',
+    },
+    ...
+  ),
 );
 ```
 

--- a/alienfile
+++ b/alienfile
@@ -17,7 +17,7 @@ share {
     meta->prop->{env}->{LIBTOOLIZE} = 'libtoolize' if $^O eq 'darwin';
 
     plugin Download => (
-        url     => 'https://dist.libuv.org/dist/v1.31.0',
+        url     => 'https://dist.libuv.org/dist/v1.35.0',
         version => qr/^libuv-v([0-9\.]+)\.tar\.gz$/,
     );
 

--- a/alienfile
+++ b/alienfile
@@ -3,6 +3,10 @@ use Config;
 
 configure { requires 'Alien::Build::Plugin::Build::Make' => '0.01' };
 
+plugin 'Probe::Vcpkg' => (
+    name     => 'libuv',
+    ffi_name => 'libuv',
+);
 plugin 'PkgConfig' => (
     pkg_name => 'libuv',
     minimum_version => '1.0.0',

--- a/alienfile
+++ b/alienfile
@@ -103,8 +103,13 @@ share {
             'sh autogen.sh',
             '%{configure}',
             '%{make}',
-            '%{make} check',
+            #'%{make} check',
             '%{make} install',
+        ];
+
+        test [
+            '%{make} check',
+            #'%{make} install',
         ];
     }
 

--- a/alienfile
+++ b/alienfile
@@ -17,7 +17,7 @@ share {
     meta->prop->{env}->{LIBTOOLIZE} = 'libtoolize' if $^O eq 'darwin';
 
     plugin Download => (
-        url     => 'https://dist.libuv.org/dist/v1.35.0',
+        url     => 'https://dist.libuv.org/dist/v1.34.2',
         version => qr/^libuv-v([0-9\.]+)\.tar\.gz$/,
     );
 

--- a/cpanfile
+++ b/cpanfile
@@ -3,23 +3,16 @@ on 'runtime' => sub {
     requires 'strict';
     requires 'warnings';
     requires 'base';
-    requires 'Alien::Base' => '1.00';
+    requires 'Alien::Base' => '2.11';
 };
 
 on 'build' => sub {
-    requires 'Alien::Build' => '1.00';
+    requires 'Alien::Build' => '2.11';
     requires 'Alien::Build::Plugin::Build::Make';
+    requires 'Alien::Build::Plugin::Probe::Vcpkg' => '2.11';
     requires 'Config';
     requires 'ExtUtils::MakeMaker';
     requires 'IPC::Cmd';
-#    if ($^O eq 'MSWin32') {
-#        requires 'Alien::Build::Plugin::Build::CMake';
-#        requires 'Alien::cmake3';
-#        requires 'Path::Tiny';
-#    }
-#    else {
-#        requires 'Alien::Autotools';
-#    };
 };
 
 on 'test' => sub {

--- a/cpanfile
+++ b/cpanfile
@@ -6,6 +6,14 @@ on 'runtime' => sub {
     requires 'Alien::Base' => '2.11';
 };
 
+on 'configure' => sub {
+    requires 'Alien::Build' => '2.11';
+    requires 'Alien::Build::MM' => '0.32';
+    requires 'Alien::Build::Plugin::Build::Make' => '0.01';
+    requires 'Alien::Build::Plugin::Probe::Vcpkg' => '2.11';
+    requires 'ExtUtils::MakeMaker' => '6.52';
+};
+
 on 'build' => sub {
     requires 'Alien::Build' => '2.11';
     requires 'Alien::Build::Plugin::Build::Make';

--- a/cpanfile
+++ b/cpanfile
@@ -3,21 +3,21 @@ on 'runtime' => sub {
     requires 'strict';
     requires 'warnings';
     requires 'base';
-    requires 'Alien::Base' => '2.11';
+    requires 'Alien::Base' => '2.15';
 };
 
 on 'configure' => sub {
-    requires 'Alien::Build' => '2.11';
+    requires 'Alien::Build' => '2.15';
     requires 'Alien::Build::MM' => '0.32';
     requires 'Alien::Build::Plugin::Build::Make' => '0.01';
-    requires 'Alien::Build::Plugin::Probe::Vcpkg' => '2.11';
+    requires 'Alien::Build::Plugin::Probe::Vcpkg' => '2.15';
     requires 'ExtUtils::MakeMaker' => '6.52';
 };
 
 on 'build' => sub {
-    requires 'Alien::Build' => '2.11';
+    requires 'Alien::Build' => '2.15';
     requires 'Alien::Build::Plugin::Build::Make';
-    requires 'Alien::Build::Plugin::Probe::Vcpkg' => '2.11';
+    requires 'Alien::Build::Plugin::Probe::Vcpkg' => '2.15';
     requires 'Config';
     requires 'ExtUtils::MakeMaker';
     requires 'IPC::Cmd';

--- a/lib/Alien/libuv.pm
+++ b/lib/Alien/libuv.pm
@@ -23,16 +23,16 @@ In your C<Makefile.PL>:
 
     use ExtUtils::MakeMaker;
     use Config;
-    use Alien::libuv;
+    use Alien::Base::Wrapper ();
 
     WriteMakefile(
-      ...
-      CONFIGURE_REQUIRES => {
-        'Alien::libuv' => '1.000',
-      },
-      CCFLAGS => Alien::libuv->cflags . " $Config{ccflags}",
-      LIBS    => [ Alien::libuv->libs ],
-      ...
+      Alien::Base::Wrapper->new('Alien::libuv')->mm_args2(
+        ...
+        CONFIGURE_REQUIRES => {
+          'Alien::libuv' => '1.000',
+        },
+        ...
+      ),
     );
 
 =head1 DESCRIPTION


### PR DESCRIPTION
This uses the `Probe::Vcpkg` plugin to discover the "system" libuv if the user is using vcpkg.  This makes it (relatively) easy to install `Alien::libuv` on a Visual C++ build of Perl.  I've also updated the documentation to use `Alien::Base::Wrapper` as the manual specifying of flags doesn't work correctly on Visual C++ Perl (ABW also handles a number of other corner cases too).